### PR TITLE
Adds the log on a new line when logging a selection

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,11 +34,13 @@ function activate(context) {
                 `console.log(\'${emoji}\', )`
               )
             } else {
+              const currentSelection = editor.document.getText(editor.selection)
+              const currentLine = editor.document.lineAt(editor.selection.start)
+              const currentLineText = currentLine.text
+
               edit.replace(
-                editor.selection,
-                `console.log(\'${emoji}\', ${editor.document.getText(
-                  editor.selection
-                )})`
+                currentLine.rangeIncludingLineBreak,
+                `${currentLineText}\nconsole.log(\'${emoji}\', ${currentSelection})\n`
               )
             }
           })
@@ -52,6 +54,9 @@ function activate(context) {
                 editor.selection.start,
                 editor.selection.end
               )
+
+              // Format document after adding new line
+              vscode.commands.executeCommand('editor.action.formatDocument')
             }
           })
       }

--- a/package.json
+++ b/package.json
@@ -6,17 +6,14 @@
 	"repository": {
 		"url": "https://github.com/jamesformica/emoji-log"
 	},
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"engines": {
-		"vscode": "^1.42.0"
+		"vscode": "^1.75.0"
 	},
 	"categories": [
 		"Other"
 	],
 	"icon": "images/icon.png",
-	"activationEvents": [
-		"onCommand:extension.emoji-log"
-	],
 	"main": "./extension.js",
 	"contributes": {
 		"commands": [


### PR DESCRIPTION
# Overview
Adds the log on a new line when logging a selection

- [x] When a selection exists, create a new line with the log
- [x] Bump `engines.vscode` to `^1.75.0` (Jan 2023)